### PR TITLE
[機能追加] 日報登録機能の作成 #4対応

### DIFF
--- a/src/main/java/com/example/study/controller/ReportController.java
+++ b/src/main/java/com/example/study/controller/ReportController.java
@@ -1,10 +1,17 @@
 package com.example.study.controller;
 
+import jakarta.validation.Valid;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import com.example.study.dto.ReportRequestDto;
 import com.example.study.service.ReportService;
 
 @Controller
@@ -18,18 +25,42 @@ public class ReportController {
 
 	@GetMapping("/reports")
 	public String getReports(Model model) {
-		
+
 		/*テスト用にuserId = 1を決め打ちで入れている*/
 		model.addAttribute("reports", reportService.getReportsByUserId(1));
-		
+
 		return "reports";
 	}
-	
+
 	/*@PathVariableでGETリクエストのパス{id}を引数で取得する*/
 	@GetMapping("/reports/{id}")
-	public String getReport(@PathVariable int id,Model model) {
-		model.addAttribute("report",reportService.getReportById(id));
+	public String getReport(@PathVariable int id, Model model) {
+		model.addAttribute("report", reportService.getReportById(id));
 		return "report-detail";
 	}
-	
+
+	@GetMapping("/reports/create")
+	public String showCreateForm(Model model) {
+		model.addAttribute("reportRequestDto", new ReportRequestDto());
+		model.addAttribute("isEdit", false);
+		return "report-form";
+	}
+
+	/* 
+	 * @ModelAttributeを利用することで自動で値を設定可能
+	 * 入力フォームのname属性とDTOのフィールド名が対応していることが条件
+	 * エラー時でもDTOがモデルにセットされているので再入力の必要がない 
+	 * */
+	@PostMapping("/reports")
+	public String createReport(@ModelAttribute @Valid ReportRequestDto dto, BindingResult result,RedirectAttributes redirectAttributes) {
+		if (result.hasErrors()) {
+			return "report-form";
+		}
+		
+		reportService.createReport(dto);
+		redirectAttributes.addFlashAttribute("successMessage","日報の登録が完了しました。");
+		
+		return "redirect:/reports";
+	}
+
 }

--- a/src/main/java/com/example/study/dto/ReportRequestDto.java
+++ b/src/main/java/com/example/study/dto/ReportRequestDto.java
@@ -1,0 +1,75 @@
+package com.example.study.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public class ReportRequestDto {
+
+	private String title;
+
+	private String content;
+	
+	private LocalDate learningDate;
+	
+	@Min(0)
+	@Max(23)
+	private int learningHours;
+	
+	private int learningMinutes;
+	
+	public ReportRequestDto() {
+		
+	}
+	
+	/*カスタムバリデーション*/
+	@AssertTrue(message = "分は0,15,30,45のいずれかを選択してください。")
+	public boolean isValidMinutes() {
+		return List.of(0,15,30,45).contains(learningMinutes);
+	}
+	
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public void setContent(String content) {
+		this.content = content;
+	}
+
+	public LocalDate getLearningDate() {
+		return learningDate;
+	}
+
+	public void setLearningDate(LocalDate learningDate) {
+		this.learningDate = learningDate;
+	}
+
+	public int getLearningHours() {
+		return learningHours;
+	}
+
+	public void setLearningHours(int learningHours) {
+		this.learningHours = learningHours;
+	}
+
+	public int getLearningMinutes() {
+		return learningMinutes;
+	}
+
+	public void setLearningMinutes(int learningMinutes) {
+		this.learningMinutes = learningMinutes;
+	}
+
+
+}

--- a/src/main/java/com/example/study/repository/ReportRepository.java
+++ b/src/main/java/com/example/study/repository/ReportRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.example.study.dto.ReportRequestDto;
 import com.example.study.entity.Report;
 
 @Repository
@@ -16,4 +17,6 @@ public interface ReportRepository extends JpaRepository<Report,Integer> {
 	
 	// 投稿済みの日報(1件)を取得
 	Optional<Report> findById(int id);
+	
+	void save(ReportRequestDto dto);
 }

--- a/src/main/java/com/example/study/service/ReportService.java
+++ b/src/main/java/com/example/study/service/ReportService.java
@@ -2,6 +2,7 @@ package com.example.study.service;
 
 import java.util.List;
 
+import com.example.study.dto.ReportRequestDto;
 import com.example.study.entity.Report;
 
 public interface ReportService {
@@ -9,5 +10,9 @@ public interface ReportService {
 	List<Report> getReportsByUserId(int userId);
 	
 	Report getReportById(int id);
+	
+	void createReport(ReportRequestDto dto);
+	
+	
 
 }

--- a/src/main/java/com/example/study/service/ReportServiceImpl.java
+++ b/src/main/java/com/example/study/service/ReportServiceImpl.java
@@ -3,7 +3,9 @@ package com.example.study.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.example.study.dto.ReportRequestDto;
 import com.example.study.entity.Report;
 import com.example.study.exception.ReportNotFoundException;
 import com.example.study.repository.ReportRepository;
@@ -11,7 +13,7 @@ import com.example.study.repository.ReportRepository;
 @Service
 public class ReportServiceImpl implements ReportService {
 
-	
+	private final double MINUTES_PER_HOUR = 60.0;
 	/*コンストラクタインジェクションを採用した理由
 	SpringFrameWorkの公式ドキュメントで推奨されているため
 	メリット
@@ -19,7 +21,7 @@ public class ReportServiceImpl implements ReportService {
 	②依存関係が明確でコードが読みやすくなる
 	③テスト時にモック注入がしやすい*/
 	private final ReportRepository reportRepository;
-	
+
 	public ReportServiceImpl(ReportRepository reportRepository) {
 		this.reportRepository = reportRepository;
 	}
@@ -33,8 +35,27 @@ public class ReportServiceImpl implements ReportService {
 
 	@Override
 	public Report getReportById(int id) {
-		
-		return reportRepository.findById(id).orElseThrow(() -> new ReportNotFoundException("日報が見つかりませんでした。(ID:"+ id + ")"));
+
+		return reportRepository.findById(id)
+				.orElseThrow(() -> new ReportNotFoundException("日報が見つかりませんでした。(ID:" + id + ")"));
+	}
+
+	@Transactional
+	public void createReport(ReportRequestDto dto) {
+		Report report = new Report();
+		report.setTitle(dto.getTitle());
+		report.setContent(dto.getContent());
+		report.setLearningDate(dto.getLearningDate());
+
+		//〇時間〇分→〇.〇hに変換して設定(DB定義に合わせるため)
+		report.setLearningHours(dto.getLearningHours() + (dto.getLearningMinutes() / MINUTES_PER_HOUR));
+
+		//認証機能が作成できるまではuserId=1で固定
+		report.setUserId(1);
+		//タグ自動登録機能を実装するまではtagId=1で固定
+		report.setTagId(1);
+
+		reportRepository.save(report);
 	}
 
 }

--- a/src/main/resources/templates/report-form.html
+++ b/src/main/resources/templates/report-form.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>日報フォーム</title>
+    <meta charset="UTF-8" />
+</head>
+<body>
+    <h1 th:text="${isEdit} ? '日報編集' : '日報登録'">日報フォーム</h1>
+
+    <form th:action="@{${isEdit} ? '/reports/update' : '/reports'}"
+          th:object="${reportRequestDto}" method="post">
+          
+        <!-- 編集モードの時だけIDをhiddenで渡す -->
+        <input type="hidden" th:if="${isEdit}" th:field="*{id}" />
+
+        <div>
+			<div th:if="${#fields.hasErrors('learningDate')}" th:errors="*{learningDate}" style="color:red"></div>
+            <label>学習日付:</label>
+            <input type="date" th:field="*{learningDate}" required />
+        </div>
+
+<!--        <div>-->
+<!--            <label>技術カテゴリー:</label>-->
+<!--            <select th:field="*{tech}">-->
+<!--                <option value="">-- 選択してください --</option>-->
+<!--                <option th:each="t : ${techList}"-->
+<!--                        th:value="${t}" th:text="${t}"></option>-->
+<!--            </select>-->
+<!--        </div>-->
+		<div>
+			<div th:if="${#fields.hasErrors('title')}" th:errors="*{title}" style="color:red"></div>
+            <label>学習概要:</label>
+            <input type="text" th:field="*{title}" required />
+        </div>
+
+        <div>
+			<div th:if="${#fields.hasErrors('content')}" th:errors="*{content}" style="color:red"></div>
+            <label>学習内容:</label><br>
+            <textarea th:field="*{content}" rows="5" cols="50" required></textarea><br>
+<!--            <span th:text="'文字数: ' + ${#strings.length(reportForm.content)} + '文字'"></span>-->
+        </div>
+
+        <div>
+			<div th:if="${#fields.hasErrors('learningHours')}" th:errors="*{learningHours}" style="color:red"></div>
+            <label>学習時間(時間)</label>
+			<select id="learningHours" name="learningHours" th:field="*{learningHours}">
+			  <th:block th:each="i : ${#numbers.sequence(0, 23)}">
+			    <option th:value="${i}" th:text="${i}">0</option>
+			  </th:block>
+			</select>
+<!--            <select th:field="*{learningHours}">-->
+<!--                <option th:each="i : ${#numbers.sequence(1, 12)}"-->
+<!--                        th:value="${i}" th:text="${i + ' 時間'}"></option>-->
+<!--            </select>-->
+			<label>学習時間(分)</label>
+			<select id="learningMinutes" name="learningMinutes">
+			  <option value="0">0</option>
+			  <option value="15">15</option>
+			  <option value="30">30</option>
+			  <option value="45">45</option>
+			</select>
+        </div>
+
+        <div>
+            <button type="submit" th:text="${isEdit} ? '更新する' : '登録する'"></button>
+        </div>
+    </form>
+
+	<form th:action="@{/reports}" method="get" style="display: inline; margin-left: 10px;">
+        <button type="submit">一覧に戻る</button>
+    </form>
+</body>
+</html>

--- a/src/main/resources/templates/reports.html
+++ b/src/main/resources/templates/reports.html
@@ -6,7 +6,10 @@
 </head>
 <body>
     <h1>学習日報一覧</h1>
-
+	
+	<div th:if="${successMessage}" class="alert alert-success" style = "color: blue">
+	  <p th:text="${successMessage}"></p>
+	</div>
     <table border="1">
         <thead>
             <tr>
@@ -44,7 +47,7 @@
 
     <!-- 新規作成ボタン -->
 	<p>
-		<form th:action="@{'/reports/create}" method="get">
+		<form th:action="@{/reports/create}" method="get">
             <button type="submit">新規登録</button>
         </form>
 	</p>


### PR DESCRIPTION
# 日報登録機能の実装

日報の新規登録機能を追加しました。
基本的な処理の流れは [日報登録機能の作成 #4](https://github.com/kirias1996/studyLog/issues/4#issue-2989974278) に沿って実装しています。

### 補足
- `userId`, `tagId` は固定値（1）で一時対応中です
- 登録完了後に一覧画面へリダイレクトし、完了メッセージを表示します
- 入力フォーム受け渡し用クラス(ReportRequestDto.java)を作成しています。

### 今後の対応予定
- ユーザ認証機能実装が完了後、userIdを動的に登録できるよう改修を行う予定です。
- タグ登録機能実装が完了次第、tagIdを画面にて設定できるよう改修を行う予定です。
