### PR TITLE
プロフィール編集機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-#‚±‚ÌƒvƒƒWƒFƒNƒg‚Å‚Í `.gitignore` ‚É]‚Á‚ÄŒÂl—p‚Ìİ’èƒtƒ@ƒCƒ‹i*.launch, .env ‚È‚Çj‚ÍGitŠÇ—‚µ‚Ü‚¹‚ñB
+#ï¿½ï¿½ï¿½Ìƒvï¿½ï¿½ï¿½Wï¿½Fï¿½Nï¿½gï¿½Å‚ï¿½ `.gitignore` ï¿½É]ï¿½ï¿½ï¿½ÄŒÂlï¿½pï¿½Ìİ’ï¿½tï¿½@ï¿½Cï¿½ï¿½ï¿½i*.launch, .env ï¿½È‚Çjï¿½ï¿½Gitï¿½Ç—ï¿½ï¿½ï¿½ï¿½Ü‚ï¿½ï¿½ï¿½B
 HELP.md
 .gradle
 build/
@@ -9,10 +9,10 @@ build/
 log/
 logs/
 
-# macOSŒÅ—L
+# macOSï¿½Å—L
 .DS_Store
 
-# ŠÂ‹«•Ï”ƒtƒ@ƒCƒ‹(¡‚Í“ü‚ê‚Ä‚¢‚È‚¢‚ª”O‚Ì‚½‚ß)
+# ï¿½Â‹ï¿½ï¿½Ïï¿½ï¿½tï¿½@ï¿½Cï¿½ï¿½(ï¿½ï¿½ï¿½Í“ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½È‚ï¿½ï¿½ï¿½ï¿½Oï¿½Ì‚ï¿½ï¿½ï¿½)
 .env
 .env.*
 
@@ -47,9 +47,12 @@ out/
 ### VS Code ###
 .vscode/
 
-# Spring Boot“Á—L‚ÌœŠO
-# application.properties / application.yml ‚Ì‚¤‚¿AŠÂ‹«‚²‚Æ‚ÉØ‚è‘Ö‚¦‚éİ’è‚Í•K—v‚É‰‚¶‚ÄœŠO
+# Spring Bootï¿½ï¿½ï¿½Lï¿½Ìï¿½ï¿½O
+# application.properties / application.yml ï¿½Ì‚ï¿½ï¿½ï¿½ï¿½Aï¿½Â‹ï¿½ï¿½ï¿½ï¿½Æ‚ÉØ‚ï¿½Ö‚ï¿½ï¿½ï¿½İ’ï¿½Í•Kï¿½vï¿½É‰ï¿½ï¿½ï¿½ï¿½Äï¿½ï¿½O
 src/main/resources/application-dev.properties
 src/main/resources/application-local.properties
 src/main/resources/application-prod.properties
 *.launch
+
+# ã‚¢ãƒ—ãƒªã‚±ãƒ¼ã‚·ãƒ§ãƒ³
+/upload/*

--- a/src/main/java/com/example/study/config/WebConfig.java
+++ b/src/main/java/com/example/study/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.example.study.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addResourceHandlers(ResourceHandlerRegistry registry) {
+		String uploadPath = System.getProperty("user.dir") + "/upload/";
+		registry.addResourceHandler("/upload/**")
+				.addResourceLocations("file:" + uploadPath);
+	}
+}

--- a/src/main/java/com/example/study/controller/userProfile/UserProfileController.java
+++ b/src/main/java/com/example/study/controller/userProfile/UserProfileController.java
@@ -1,15 +1,25 @@
 package com.example.study.controller.userProfile;
 
+import jakarta.validation.Valid;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.InitBinder;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import com.example.study.dto.UserProfileDto;
 import com.example.study.entity.User;
 import com.example.study.security.CustomUserDetails;
 import com.example.study.security.LoginUserProvider;
 import com.example.study.service.UserProfileService;
+import com.example.study.validation.UserProfileValidator;
 
 @Controller
 public class UserProfileController {
@@ -19,14 +29,17 @@ public class UserProfileController {
 
 	private final UserProfileService userProfileService;
 	private final LoginUserProvider loginUserProvider;
+	private final UserProfileValidator userProfileValidator;
 
-	public UserProfileController(UserProfileService userProfileService, LoginUserProvider loginUserProvider) {
+	public UserProfileController(UserProfileService userProfileService, LoginUserProvider loginUserProvider,
+			UserProfileValidator userProfileValidator) {
 		this.userProfileService = userProfileService;
 		this.loginUserProvider = loginUserProvider;
+		this.userProfileValidator = userProfileValidator;
 	}
 
 	@GetMapping("/userProfile")
-	public String showUserProfileForm(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
+	public String showUserProfile(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
 		//ログインユーザの情報を取得してServiceクラスに渡す
 		User user = loginUserProvider.getLoginUser(userDetails);
 
@@ -37,5 +50,46 @@ public class UserProfileController {
 		 * */
 		model.addAttribute("userProfile", userProfileService.toUserProfileDto(user, userDetails.getUsername()));
 		return "userProfile/userProfileView";
+	}
+
+	@GetMapping("/userProfile/edit")
+	public String showUserProfileForm(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
+		//ログインユーザの情報を取得してServiceクラスに渡す
+		User user = loginUserProvider.getLoginUser(userDetails);
+
+		/*
+		 * SpringSecurityのUserDetails(認証情報を管理するクラス)のメソッドがgetUsernameとなっている
+		 * そのクラスを実装し、OverrideしているメソッドのためgetUsernameといったメソッド名を指定
+		 * 中身としてはメールアドレスを取得している
+		 * */
+		model.addAttribute("userProfile", userProfileService.toUserProfileDto(user, userDetails.getUsername()));
+		return "userProfile/userProfileEdit";
+	}
+
+	@InitBinder("userProfile")
+	protected void initBinder(WebDataBinder dataBinder) {
+		dataBinder.addValidators(userProfileValidator);
+	}
+
+	/*DB更新なのにPUTではなくPOSTを採用している理由
+	 * HTMLの仕様でmethod=GET,POSTメソッドのみサポートされている
+	 * Springの挙動としてmultipart/form-data + PUT は MultipartResolver や 
+	 * BindingResult が正しく機能しないことがある
+	 * 上記の理由からバリデーションやバインドが正常に動作させるためにPOSTを採用している
+	*/
+	@PostMapping("/userProfile")
+	public String editUserProfile(@ModelAttribute("userProfile") @Valid UserProfileDto dto,
+			BindingResult result, @AuthenticationPrincipal CustomUserDetails userDetails,
+			RedirectAttributes redirectAttributes) {
+		if (result.hasErrors()) {
+			return "userProfile/userProfileEdit";
+		}
+
+		//ログインユーザの情報を取得してDB更新条件に利用
+		User user = loginUserProvider.getLoginUser(userDetails);
+		userProfileService.updateUserProfile(user, dto);
+		redirectAttributes.addFlashAttribute("successMessage", "プロフィール編集が完了しました。");
+
+		return "redirect:/userProfile";
 	}
 }

--- a/src/main/java/com/example/study/dto/UserProfileDto.java
+++ b/src/main/java/com/example/study/dto/UserProfileDto.java
@@ -1,14 +1,25 @@
 package com.example.study.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import org.springframework.web.multipart.MultipartFile;
+
 public class UserProfileDto {
-	
+	/*emailは表示用でユーザからの変更を受け付けない仕様のため
+	バリデーションチェックをしない*/
 	private String email;
 	
+	@NotBlank
+	@Size(max = 50,message="ユーザ名は{max}文字以内で入力してください。")
 	private String userName;
 	
+	@Size(max = 255,message="プロフィール文は{max}文字以内で入力してください。")
 	private String profileText;
 	
 	private String iconUrl;
+	
+	private MultipartFile iconImage;
 	
 	private boolean defaultIcon;
 	
@@ -45,6 +56,14 @@ public class UserProfileDto {
 
 	public void setIconUrl(String iconUrl) {
 		this.iconUrl = iconUrl;
+	}
+
+	public MultipartFile getIconImage() {
+		return iconImage;
+	}
+
+	public void setIconImage(MultipartFile iconImage) {
+		this.iconImage = iconImage;
 	}
 
 	public boolean isDefaultIcon() {

--- a/src/main/java/com/example/study/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/study/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 /*アプリケーション全体で共通の例外処理を定義するクラス*/
 @ControllerAdvice
@@ -19,6 +20,18 @@ public class GlobalExceptionHandler {
 	public String handleAccessDenied(AccessDeniedException ex,Model model) {
 		model.addAttribute("errorMessage",ex.getMessage());
 		return "error/report-access-deny";
+	}
+	
+	@ExceptionHandler(RuntimeException.class)
+	public String handleException(RuntimeException ex, Model model) {
+		model.addAttribute("errorMessage", ex.getMessage());
+		return "error/exception";
+	}
+	
+	@ExceptionHandler(MaxUploadSizeExceededException.class)
+	public String handleMaxUploadSizeExceeded(MaxUploadSizeExceededException ex,Model model) {
+		model.addAttribute("errorMessage", "アップロードできるファイルサイズは10MBまでです。");
+		return "error/exception";
 	}
 	
 }

--- a/src/main/java/com/example/study/service/UserProfileService.java
+++ b/src/main/java/com/example/study/service/UserProfileService.java
@@ -4,5 +4,7 @@ import com.example.study.dto.UserProfileDto;
 import com.example.study.entity.User;
 
 public interface UserProfileService {
-	UserProfileDto toUserProfileDto(User user,String email);
+	UserProfileDto toUserProfileDto(User user, String email);
+
+	void updateUserProfile(User user, UserProfileDto dto);
 }

--- a/src/main/java/com/example/study/service/UserProfileServiceImpl.java
+++ b/src/main/java/com/example/study/service/UserProfileServiceImpl.java
@@ -1,27 +1,97 @@
 package com.example.study.service;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.example.study.dto.UserProfileDto;
 import com.example.study.entity.User;
+import com.example.study.repository.UserRepository;
 
 @Service
 public class UserProfileServiceImpl implements UserProfileService {
 
 	@Value("${app.default-icon-path}")
 	String defaultIconUrl;
-	
+
+	private final UserRepository userRepository;
+
+	public UserProfileServiceImpl(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
 	@Override
-	public UserProfileDto toUserProfileDto(User user,String email) {
+	public UserProfileDto toUserProfileDto(User user, String email) {
 		UserProfileDto dto = new UserProfileDto();
-		
+
 		dto.setEmail(email);
 		dto.setUserName(user.getUserName());
 		dto.setProfileText(user.getProfileText());
-		dto.setIconUrl(user.getIconUrl());
-		dto.setDefaultIcon(user.getIconUrl().equals(defaultIconUrl));
-				
+		if (user.getIconUrl() == null) {
+			dto.setIconUrl(defaultIconUrl);
+			dto.setDefaultIcon(false);
+		} else {
+			dto.setIconUrl(user.getIconUrl());
+			dto.setDefaultIcon(user.getIconUrl().equals(defaultIconUrl));
+		}
+
 		return dto;
+	}
+
+	/*
+	 * Controllerクラスでuserのnullチェック,dtoのバリデーションチェック済みのため
+	 * Serviceクラスではチェック処理は実施しない
+	 * */
+	@Override
+	@Transactional
+	public void updateUserProfile(User user, UserProfileDto dto) {
+		String uploadFilePath = null;
+		String baseFilePath = System.getProperty("user.dir");
+		try {
+			if (dto.getIconImage() != null && !dto.getIconImage().isEmpty()) {
+				uploadFilePath = saveIconImage(dto.getIconImage());
+				user.setIconUrl(uploadFilePath);
+
+			}
+			user.setUserName(dto.getUserName());
+			user.setProfileText(dto.getProfileText());
+			userRepository.save(user);
+		} catch (Exception e) {
+			//DB更新失敗時に保存済みアップロードファイルを削除
+			if (uploadFilePath != null) {
+				deleteFile(baseFilePath + uploadFilePath);
+			}
+
+			throw new RuntimeException("プロフィール更新に失敗しました。");
+		}
+	}
+
+	/*
+	 * アイコン画像の保存に失敗したときにはユーザの想定しないアイコン画像が表示される可能性があるため
+	 * エラー画面に遷移させる。
+	 * */
+	private String saveIconImage(MultipartFile file) throws IOException {
+		String uploadDir = System.getProperty("user.dir") + "/upload/";
+		String fileName = UUID.randomUUID().toString() + file.getOriginalFilename();
+		Path filePath = Paths.get(uploadDir, fileName);
+		Files.copy(file.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
+		return "/upload/" + fileName;
+	}
+
+	private void deleteFile(String filePath) {
+		try {
+			Path path = Paths.get(filePath);
+			Files.deleteIfExists(path);
+		} catch (IOException e) {
+			System.err.println("ファイル削除に失敗しました。:" + filePath);
+		}
 	}
 }

--- a/src/main/java/com/example/study/validation/UserProfileValidator.java
+++ b/src/main/java/com/example/study/validation/UserProfileValidator.java
@@ -1,0 +1,51 @@
+package com.example.study.validation;
+
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.example.study.dto.UserProfileDto;
+
+@Component
+public class UserProfileValidator implements Validator {
+
+	@Override
+	public boolean supports(Class<?> clazz) {
+		/*
+		 * UserProfileDtoクラスと同じかサブクラスならtrueを返す
+		 * isAssinableFromを使うことで他のDtoでバリエーションが使われることを防ぐ
+		 * */
+		return UserProfileDto.class.isAssignableFrom(clazz);
+	}
+
+	@Override
+	public void validate(Object target, Errors errors) {
+		UserProfileDto dto = (UserProfileDto) target;
+		MultipartFile file = dto.getIconImage();
+
+		if (file == null || file.isEmpty()) {
+			return;
+		}
+		//ファイル拡張子チェック
+		validateFileExtension(file, errors);
+		//ファイルサイズチェック
+		validateMaxFileSize(file, errors);
+	}
+
+	private void validateFileExtension(MultipartFile file, Errors errors) {
+		/*(?i)で大文字/小文字を区別しない正規表現マッチングを適用*/
+		if (file.getOriginalFilename() != null || !file.isEmpty()
+				|| !file.getOriginalFilename().matches("(?i)^.+\\.(png|jpg|jpeg)$")) {
+			errors.rejectValue("iconImage", "file.invalid", "対応していないファイル形式です。PNGまたはJPG形式の画像を指定してください。");
+		}
+	}
+
+	private void validateMaxFileSize(MultipartFile file, Errors errors) {
+		// サイズチェック（2MB = 2 * 1024 * 1024）
+		if (file.getSize() > 2 * 1024 * 1024) {
+			errors.rejectValue("iconImage", "file.maxsize.over", "ファイルサイズが2MBを超えています。2MB以下の画像を指定してください。");
+		}
+	}
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,5 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.profiles.active=${HOST}
 spring.mvc.hiddenmethod.filter.enabled=true
 app.default-icon-path=/image/default-icon.png
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB

--- a/src/main/resources/templates/error/exception.html
+++ b/src/main/resources/templates/error/exception.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title th:text="${errorTitle}">エラーページ</title>
+</head>
+<body>
+    <h1 th:text="${errorMessage}"></h1>
+    <a th:href="@{/reports}">日報一覧画面に戻る</a>
+</body>
+</html>
+

--- a/src/main/resources/templates/userProfile/userProfileEdit.html
+++ b/src/main/resources/templates/userProfile/userProfileEdit.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+	<meta charset="UTF-8">
+	<title>プロフィール編集</title>
+</head>
+
+<body>
+
+	<h1>プロフィール編集</h1>
+
+	<!-- プロフィール編集フォーム -->
+	<form th:action="@{/userProfile}" th:object="${userProfile}" method="post" enctype="multipart/form-data">
+		<!-- バリデーションエラー全体メッセージ -->
+		<div th:if="${#fields.hasErrors()}">
+			<p style="color: red;">入力内容にエラーがあります。修正してください。</p>
+		</div>
+
+		<!-- PUTメソッドを送信するためのhiddenフィールド -->
+<!--		<input type="hidden" name="_method" value="put" />-->
+
+		<!-- メールアドレス（出力専用） -->
+		<div>
+			<label for="email">メールアドレス</label><br>
+			<input type="email" id="email" th:field="*{email}" readonly />
+		</div>
+
+		<br>
+
+		<!-- ユーザ名 -->
+		<div>
+			<label for="userName">ユーザ名</label><br>
+			<input type="text" id="userName" th:field="*{userName}" />
+			<div th:if="${#fields.hasErrors('userName')}" style="color: red;">
+				<p th:errors="*{userName}">ユーザ名エラー</p>
+			</div>
+		</div>
+
+		<br>
+
+		<!-- プロフィール文 -->
+		<div>
+			<label for="profileText">プロフィール文</label><br>
+			<textarea id="profileText" th:field="*{profileText}" rows="5" cols="40"></textarea>
+			<div th:if="${#fields.hasErrors('profileText')}" style="color: red;">
+				<p th:errors="*{profileText}">プロフィール文エラー</p>
+			</div>
+		</div>
+
+		<br>
+
+		<!-- アイコン画像アップロード -->
+		<div>
+			<label for="iconImage">アイコン画像</label><br>
+			<input type="file" id="iconImage" name="iconImage" />
+			<div th:if="${#fields.hasErrors('iconImage')}" style="color: red;">
+			    <ul>
+			        <li th:each="err : ${#fields.errors('iconImage')}" th:text="${err}"></li>
+			    </ul>
+			</div>
+
+		</div>
+
+		<br>
+
+		<!-- 送信ボタン -->
+		<div>
+			<button type="submit">更新する</button>
+		</div>
+	</form>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/userProfile/userProfileView.html
+++ b/src/main/resources/templates/userProfile/userProfileView.html
@@ -5,6 +5,10 @@
     <title>ユーザプロフィール</title>
 </head>
 <body>
+	<div th:if="${successMessage}" class="alert alert-success" style="color: blue">
+		<p th:text="${successMessage}"></p>
+	</div>
+	
     <h1>ユーザプロフィール</h1>
 
     <div>


### PR DESCRIPTION
ユーザープロフィール編集機能のPRコメントです。  
ユーザーが自身のプロフィール情報（名前、アイコン画像、プロフィール文）を編集できる機能を実装しました。

[プロフィール編集機能の実装 #11](https://github.com/kirias1996/studyLog/issues/11)に基づいて機能を実装いたしました。

### 実装内容

- プロフィール編集画面の追加
  1. Controllerクラスに(GET:/userProfile/edit)のエンドポイントを追加
  2. 編集用フォーム(userProfileEdit.html)の新規作成

- バリデーションチェックの実装
  - ユーザ名: null禁止、DB定義以上の文字数でエラー
  - アイコン画像: （アップロード時のみ）DB定義以上の文字数、2MB超過、png/jpg/jpeg以外でエラー
  - プロフィール文: null許容、DB定義以上の文字数でエラー

- ユーザプロフィール編集機能の実装
  1. Controllerクラスに(POST:/userProfile)エンドポイント追加
  2. バリデーションエラー時にエラーメッセージ表示
  3. ログインユーザ情報をServiceクラスに渡す
  4. Userクラスにセット & /upload/フォルダにファイル保存
  5. DB更新失敗時、保存済ファイル削除
  6. ファイル保存失敗時はエラー画面へ遷移

### 補足

#### 静的リソース設定
- /StudyLog/uploads/フォルダを静的リソースに追加(/config/WebConfig.java参照)

#### カスタムバリデーション
- UserProfileValidator.javaを作成

#### POST採用理由
- HTMLの仕様（GET/POSTのみサポート）
- Springの挙動（multipart/form-data + PUT は問題が発生する可能性あり）
- 上記理由からPOSTを採用

### 動作確認内容
- 正常・異常系の手動テスト実施済み
- 各バリデーション条件でのエラー表示を確認
