### PR TITLE
ダッシュボード画面&学習時間集計機能の実装

### DIFF
--- a/src/main/java/com/example/study/config/SecurityConfig.java
+++ b/src/main/java/com/example/study/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
 					.loginProcessingUrl("/auth/login")
 					.loginPage("/login")
 					.usernameParameter("email")
-					.defaultSuccessUrl("/reports")
+					.defaultSuccessUrl("/dashboard")
 					.failureUrl("/login?error")
 					.permitAll())
 				.logout(logout -> logout

--- a/src/main/java/com/example/study/controller/dashboard/DashboardController.java
+++ b/src/main/java/com/example/study/controller/dashboard/DashboardController.java
@@ -1,0 +1,17 @@
+package com.example.study.controller.dashboard;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class DashboardController {
+	
+	@GetMapping("/dashboard")
+	public String showDashboard(Model model) {
+		model.addAttribute("postCount", 5);
+	    model.addAttribute("totalStudyTime", "10h");
+	    model.addAttribute("streakCount", 3);
+		return "dashboard/index";
+	}
+}

--- a/src/main/java/com/example/study/controller/dashboard/DashboardController.java
+++ b/src/main/java/com/example/study/controller/dashboard/DashboardController.java
@@ -1,17 +1,31 @@
 package com.example.study.controller.dashboard;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import com.example.study.entity.User;
+import com.example.study.security.CustomUserDetails;
+import com.example.study.security.LoginUserProvider;
+import com.example.study.service.ReportService;
+
 @Controller
 public class DashboardController {
+	private final ReportService reportService;
+	private final LoginUserProvider loginUserProvider;
+	
+	public DashboardController(ReportService reportService,LoginUserProvider loginUserProvider) {
+		this.reportService = reportService;
+		this.loginUserProvider = loginUserProvider;
+	}
 	
 	@GetMapping("/dashboard")
-	public String showDashboard(Model model) {
-		model.addAttribute("postCount", 5);
-	    model.addAttribute("totalStudyTime", "10h");
-	    model.addAttribute("streakCount", 3);
+	public String showDashboard(@AuthenticationPrincipal CustomUserDetails userDetails,Model model) {
+		User user = loginUserProvider.getLoginUser(userDetails);
+		model.addAttribute("postCount", reportService.getTotalLearningDays(user.getId()));
+	    model.addAttribute("totalStudyTime", reportService.getTotalLearningTimes(user.getId()));
+	    model.addAttribute("streakCount", reportService.getConsecutiveLearningDays(user.getId()));
 		return "dashboard/index";
 	}
 }

--- a/src/main/java/com/example/study/repository/ReportRepository.java
+++ b/src/main/java/com/example/study/repository/ReportRepository.java
@@ -1,9 +1,11 @@
 package com.example.study.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.example.study.dto.ReportRequestDto;
@@ -23,4 +25,16 @@ public interface ReportRepository extends JpaRepository<Report,Integer> {
 	void deleteById(int id);
 	
 	boolean existsById(int id);
+	
+	//累計学習時間の取得
+	@Query("SELECT SUM(r.learningHours) FROM Report r WHERE r.userId = :userId")
+	Double findTotalLearningTimes(int userId);
+	
+	//日報投稿日数の取得
+	@Query("SELECT COUNT(DISTINCT r.learningDate) FROM Report r WHERE r.userId = :userId")
+	Integer findTotalLearningDays(int userId);
+	
+	//連続日報投稿数の取得
+	@Query("SELECT DISTINCT r.learningDate FROM Report r WHERE r.userId = :userId ORDER BY r.learningDate DESC")
+	List<LocalDate> findLearningDays(int userId);
 }

--- a/src/main/java/com/example/study/service/ReportService.java
+++ b/src/main/java/com/example/study/service/ReportService.java
@@ -23,4 +23,10 @@ public interface ReportService {
 	void deleteReport(int reportId,int userId);
 
 	boolean existById(int id);
+	
+	double getTotalLearningTimes(int userId);
+	
+	int getTotalLearningDays(int userId);
+	
+	int getConsecutiveLearningDays(int userId);
 }

--- a/src/main/java/com/example/study/service/ReportServiceImpl.java
+++ b/src/main/java/com/example/study/service/ReportServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.study.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -121,6 +122,50 @@ public class ReportServiceImpl implements ReportService {
 	@Override
 	public boolean existById(int id) {
 		return reportRepository.existsById(id);
+	}
+
+	@Override
+	public double getTotalLearningTimes(int userId) {
+		Double result = reportRepository.findTotalLearningTimes(userId);
+
+		if (result == null) {
+			return 0.0;
+		}
+		return result;
+	}
+
+	@Override
+	public int getTotalLearningDays(int userId) {
+		Integer result = reportRepository.findTotalLearningDays(userId);
+		if (result == null) {
+			return 0;
+		}
+
+		return result;
+	}
+
+	@Override
+	public int getConsecutiveLearningDays(int userId) {
+		List<LocalDate> learningDays = reportRepository.findLearningDays(userId);
+
+		if (learningDays.isEmpty()) {
+			return 0;
+		}
+
+		LocalDate prevDate = learningDays.get(0);
+		int consecutiveCount = 1;
+
+		for (int i = 1; i < learningDays.size(); i++) {
+			if (learningDays.get(i).equals(prevDate.minusDays(1))) {
+				consecutiveCount++;
+				prevDate = learningDays.get(i);
+				
+			} else {
+				return consecutiveCount;
+			}
+
+		}
+		return consecutiveCount;
 	}
 
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -79,3 +79,19 @@ table {
     opacity: 1;
     background-color: burlywood;
 }
+
+.summary-item {
+    display: flex;
+    justify-content: space-between;
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+.summary-label {
+    font-weight: bold;
+}
+
+.summary-value {
+    font-size: 1.2em;
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1,0 +1,81 @@
+header {
+    height: 100px;
+    background-color: #808080;
+    position: relative;
+}
+
+.logout-btn {
+    color: white;
+    border: solid 1px #CCFFFF;
+    border-radius: 10px;
+    padding: 5px;
+    position: absolute;
+    top: 30px;
+    right: 30px;
+    text-decoration: none;
+}
+
+.wrapper {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+}
+
+.sidebar {
+    width: 220px;
+    height: 600px;
+    background-color: #CCFFFF;
+}
+
+.side-btn {
+    color:black;
+}
+
+.sidebar ul {
+    margin-top: 50px;
+}
+
+.sidebar ul li {
+    margin: 10px 0;
+}
+
+.main {
+    height: 600px;
+}
+
+h1 {
+    text-align: center;
+    text-decoration: underline;
+}
+
+table {
+    margin: 0 auto;
+    border-radius: 10px;
+}
+
+.userProfile {
+	text-align: left;
+}
+
+
+/* 編集ボタン・一覧に戻るボタン・削除ボタン */
+.btn1 {
+    text-align: center;
+}
+
+.btn-style {
+    border: 1px solid #000;
+    padding: 5px 10px;
+    border-radius: 10px;
+    background-color: blanchedalmond;
+    opacity: 0.7;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    color: #000;
+    text-decoration: none;
+    transition: opacity 0.5s, background-color 0.5s;
+}
+
+.btn-style:hover {
+    opacity: 1;
+    background-color: burlywood;
+}

--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -14,15 +14,15 @@
 		<div class="main">
 		    <div class="summary-item">
 		        <span class="summary-label">日報投稿日数:</span>
-		        <span class="summary-value" th:text="${postCount}">5</span>
+		        <span class="summary-value" th:text="${postCount}+'day'">5</span>
 		    </div>
 		    <div class="summary-item">
 		        <span class="summary-label">総合学習時間:</span>
-		        <span class="summary-value" th:text="${totalStudyTime}">10時間</span>
+		        <span class="summary-value" th:text="${totalStudyTime}+'h'">10時間</span>
 		    </div>
 		    <div class="summary-item">
 		        <span class="summary-label">連続投稿日数:</span>
-		        <span class="summary-value" th:text="${streakCount}">3日</span>
+		        <span class="summary-value" th:text="${streakCount}+'day'">3日</span>
 		    </div>
 		</div>
 	</div>

--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+	<meta charset="UTF-8">
+	<title>ダッシュボード</title>
+	<link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+
+<body>
+	<header th:replace="~{header::headerArea}"></header>
+	<div class="wrapper">
+		<div class="sidebar" th:replace="~{fragments/sidebar :: sidebar}"></div>
+		<div class="main">
+		    <div class="summary-item">
+		        <span class="summary-label">日報投稿日数:</span>
+		        <span class="summary-value" th:text="${postCount}">5</span>
+		    </div>
+		    <div class="summary-item">
+		        <span class="summary-label">総合学習時間:</span>
+		        <span class="summary-value" th:text="${totalStudyTime}">10時間</span>
+		    </div>
+		    <div class="summary-item">
+		        <span class="summary-label">連続投稿日数:</span>
+		        <span class="summary-value" th:text="${streakCount}">3日</span>
+		    </div>
+		</div>
+	</div>
+	
+</body>
+
+</html>

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -1,0 +1,13 @@
+   <div th:fragment="sidebar" class="sidebar">
+       <ul>
+           <li>
+               <a class="side-btn" th:href="@{/dashboard}">ダッシュボード</a>
+           </li>
+           <li>
+               <a class="side-btn" th:href="@{/userProfile}">ユーザープロフィール</a>
+           </li>
+           <li>
+               <a class="side-btn" th:href="@{/reports}">日報一覧</a>
+           </li>
+       </ul>
+   </div>

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -4,11 +4,9 @@
  -->
 <header th:fragment="headerArea">
     <nav>
-<!--        <a href="/dashboard">ダッシュボード</a>-->
-        <a href="/reports">日報一覧</a>
         <form th:action="@{/auth/logout}" method="post" style="display:inline;">
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
-            <button type="submit">ログアウト</button>
+            <button type="submit" class="logout-btn">ログアウト</button>
         </form>
     </nav>
 </header>

--- a/src/main/resources/templates/report-detail.html
+++ b/src/main/resources/templates/report-detail.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
 </head>
 <body>
-	<header th:replace="header::headerArea"></header>
+	<header th:replace="~{header::headerArea}"></header>
 	
     <h1>日報詳細</h1>
 

--- a/src/main/resources/templates/report-form.html
+++ b/src/main/resources/templates/report-form.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
 </head>
 <body>
-	<header th:replace="header::headerArea"></header>
+	<header th:replace="~{header::headerArea}"></header>
 	
     <h1 th:text="${isEdit} ? '日報編集' : '日報登録'">日報フォーム</h1>
 

--- a/src/main/resources/templates/reports.html
+++ b/src/main/resources/templates/reports.html
@@ -4,61 +4,68 @@
 <head>
 	<meta charset="UTF-8">
 	<title>日報一覧</title>
+	<link rel="stylesheet" th:href="@{/css/style.css}"></style>
 </head>
 
 <body>
-	<header th:replace="header::headerArea"></header>
+	<header th:replace="~{header::headerArea}"></header>
+	<div class = "wrapper">
+		<div class="sidebar" th:replace="~{fragments/sidebar :: sidebar}"></div>
+		<div class="main">
+			<h1>学習日報一覧</h1>
+		
+			<div th:if="${successMessage}" class="alert alert-success" style="color: blue">
+				<p th:text="${successMessage}"></p>
+			</div>
+			<div th:if="${errorMessage}" class="alert alert-success" style="color: red">
+				<p th:text="${errorMessage}"></p>
+			</div>
+			<table border="1">
+				<thead>
+					<tr>
+						<th>学習日付</th>
+						<th>タイトル</th>
+						<th>内容</th>
+						<th>学習時間（h）</th>
+						<th>操作</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr th:each="report : ${reports}">
+						<td th:text="${report.learningDate}"></td>
+						<td th:text="${report.title}"></td>
+						<td th:text="${report.content}"></td>
+						<td th:text="${report.learningHours}"></td>
+						<td>
+							<!-- 詳細ボタン -->
+							<form th:action="@{'/reports/' + ${report.id}}" method="get" style="display:inline;">
+								<button type="submit">詳細</button>
+							</form>
+							<!-- 更新ボタン -->
+							<form th:action="@{'/reports/edit/' + ${report.id}}" method="get" style="display:inline;">
+								<button type="submit">編集</button>
+							</form>
+		
+							<!-- 削除ボタン（formでPOST送信） -->
+							<form th:action="@{'/reports/' + ${report.id}}" method="post" style="display:inline;">
+								<input type="hidden" name="_method" value="delete" />
+								<button type="submit" onclick="return confirm('本当に削除しますか？')">削除</button>
+							</form>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		
+			<!-- 新規作成ボタン -->
+			<div>
+				<form th:action="@{/reports/create}" method="get">
+					<button type="submit">新規登録</button>
+				</form>
+			</div>
+			
+		</div>
+	</div>
 	
-	<h1>学習日報一覧</h1>
-
-	<div th:if="${successMessage}" class="alert alert-success" style="color: blue">
-		<p th:text="${successMessage}"></p>
-	</div>
-	<div th:if="${errorMessage}" class="alert alert-success" style="color: red">
-		<p th:text="${errorMessage}"></p>
-	</div>
-	<table border="1">
-		<thead>
-			<tr>
-				<th>学習日付</th>
-				<th>タイトル</th>
-				<th>内容</th>
-				<th>学習時間（h）</th>
-				<th>操作</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr th:each="report : ${reports}">
-				<td th:text="${report.learningDate}"></td>
-				<td th:text="${report.title}"></td>
-				<td th:text="${report.content}"></td>
-				<td th:text="${report.learningHours}"></td>
-				<td>
-					<!-- 詳細ボタン -->
-					<form th:action="@{'/reports/' + ${report.id}}" method="get" style="display:inline;">
-						<button type="submit">詳細</button>
-					</form>
-					<!-- 更新ボタン -->
-					<form th:action="@{'/reports/edit/' + ${report.id}}" method="get" style="display:inline;">
-						<button type="submit">編集</button>
-					</form>
-
-					<!-- 削除ボタン（formでPOST送信） -->
-					<form th:action="@{'/reports/' + ${report.id}}" method="post" style="display:inline;">
-						<input type="hidden" name="_method" value="delete" />
-						<button type="submit" onclick="return confirm('本当に削除しますか？')">削除</button>
-					</form>
-				</td>
-			</tr>
-		</tbody>
-	</table>
-
-	<!-- 新規作成ボタン -->
-	<p>
-	<form th:action="@{/reports/create}" method="get">
-		<button type="submit">新規登録</button>
-	</form>
-	</p>
 </body>
 
 </html>

--- a/src/main/resources/templates/reports.html
+++ b/src/main/resources/templates/reports.html
@@ -4,7 +4,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>日報一覧</title>
-	<link rel="stylesheet" th:href="@{/css/style.css}"></style>
+	<link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
 
 <body>

--- a/src/main/resources/templates/userProfile/userProfileView.html
+++ b/src/main/resources/templates/userProfile/userProfileView.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>ユーザプロフィール</title>
-	<link rel="stylesheet" th:href="@{/css/style.css}"></style>
+	<link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
 <body>
 	<div class="wrapper">

--- a/src/main/resources/templates/userProfile/userProfileView.html
+++ b/src/main/resources/templates/userProfile/userProfileView.html
@@ -33,6 +33,9 @@
 		            <a href="https://www.ac-illust.com/" target="_blank" rel="noopener noreferrer">イラストAC</a>
 		        </p>
 		    </div>
+			<div>
+				<a class="btn-style" th:href="@{/userProfile/edit}">プロフィール編集</a>
+			</div>
 		</div>
 	</div>
 

--- a/src/main/resources/templates/userProfile/userProfileView.html
+++ b/src/main/resources/templates/userProfile/userProfileView.html
@@ -3,32 +3,38 @@
 <head>
     <meta charset="UTF-8">
     <title>ユーザプロフィール</title>
+	<link rel="stylesheet" th:href="@{/css/style.css}"></style>
 </head>
 <body>
-	<div th:if="${successMessage}" class="alert alert-success" style="color: blue">
-		<p th:text="${successMessage}"></p>
+	<div class="wrapper">
+		<div th:replace="~{fragments/sidebar :: sidebar}"></div>
+		<div class="main">
+			<div th:if="${successMessage}" class="alert alert-success" style="color: blue">
+				<p th:text="${successMessage}"></p>
+			</div>
+			
+		    <h1 class="userProfile">ユーザプロフィール</h1>
+		
+		    <div>
+		        <!-- プロフィール画像 -->
+		        <img th:src="@{${userProfile.iconUrl}}" alt="プロフィール画像" width="150" height="150">
+		    </div>
+		
+		    <div>
+		        <p><strong>ユーザ名：</strong> <span th:text="${userProfile.userName}">ユーザ名</span></p>
+		        <p><strong>メールアドレス：</strong> <span th:text="${userProfile.email}">example@example.com</span></p>
+		        <p><strong>自己紹介：</strong> <span th:text="${userProfile.profileText}">ここに自己紹介が入ります</span></p>
+		    </div>
+		
+		    <!-- デフォルトアイコンの時だけクレジット表記を表示 -->
+		    <div th:if="${userProfile.isDefaultIcon()}">
+		        <p style="font-size: 0.8em;">
+		            アイコンイラスト提供：
+		            <a href="https://www.ac-illust.com/" target="_blank" rel="noopener noreferrer">イラストAC</a>
+		        </p>
+		    </div>
+		</div>
 	</div>
-	
-    <h1>ユーザプロフィール</h1>
-
-    <div>
-        <!-- プロフィール画像 -->
-        <img th:src="@{${userProfile.iconUrl}}" alt="プロフィール画像" width="150" height="150">
-    </div>
-
-    <div>
-        <p><strong>ユーザ名：</strong> <span th:text="${userProfile.userName}">ユーザ名</span></p>
-        <p><strong>メールアドレス：</strong> <span th:text="${userProfile.email}">example@example.com</span></p>
-        <p><strong>自己紹介：</strong> <span th:text="${userProfile.profileText}">ここに自己紹介が入ります</span></p>
-    </div>
-
-    <!-- デフォルトアイコンの時だけクレジット表記を表示 -->
-    <div th:if="${userProfile.isDefaultIcon()}">
-        <p style="font-size: 0.8em;">
-            アイコンイラスト提供：
-            <a href="https://www.ac-illust.com/" target="_blank" rel="noopener noreferrer">イラストAC</a>
-        </p>
-    </div>
 
 </body>
 </html>


### PR DESCRIPTION
## ダッシュボード画面&学習時間集計機能を実装しました。

基本的な処理の流れは以下のIssueに沿って実装しています
[ダッシュボード画面の作成](https://github.com/kirias1996/studyLog/issues/16#issue-2990838227)
[累計学習時間](https://github.com/kirias1996/studyLog/issues/13#issue-2990836224)
[累計日報投稿日数](https://github.com/kirias1996/studyLog/issues/12#issue-2990835789)
[連続投稿日数](https://github.com/kirias1996/studyLog/issues/14#issue-2990836964)



---

### 実装内容

#### **ダッシュボード画面の作成**

- サイドバー内のリンク（例：ダッシュボード、ユーザープロフィール、日報一覧）の遷移先を設定。 
- ダッシュボード画面に表示領域を作成
- Spring Security設定の `UserDetails`（ログイン成功時のリダイレクトURL）を `/dashboard` に変更
- DashboardControllerクラスを新設(GET;/dashboard)  


#### **累計学習時間の集計&表示**

- コントローラクラスにてログインユーザ情報を取得(`@AuthenticationPrincipal`を使用) 
- リポジトリクラスに **カスタムクエリメソッド** を定義
  - ログインユーザIDで絞り込み  
  - 学習時間を `SUM` 集計  
- サービスクラスにて定義済みのカスタムクエリメソッドを呼び出し、累計学習時間を取得
- 取得した累計学習時間をビュー上に表示
- 日報が1件もない場合0.0を返す処理を追加 


#### **累計日報投稿数の集計&表示**

- コントローラクラスにてログインユーザ情報を取得(`@AuthenticationPrincipal`を使用) 
- リポジトリクラスに **カスタムクエリメソッド** を定義
  - ログインユーザIDで絞り込み  
  - 学習日でDISTINCTをかけてCOUNT関数で集計  
- サービスクラスにて定義済みのカスタムクエリメソッドを呼び出し、累計日報投稿数を取得
- 取得した累計日報投稿数をビュー上に表示
- 日報が1件もない場合0を返す処理を追加 


#### **連続投稿日数の集計&表示**

- コントローラクラスにてログインユーザ情報を取得(`@AuthenticationPrincipal`を使用) 
- リポジトリクラスに **カスタムクエリメソッド** を定義
  - ログインユーザIDで絞り込み  
  - 学習日でDISTINCTをかけて降順で学習日のみ取得
  - リスト形式で取得しサービスクラスで連続投稿数の判定ロジックを実装  
- サービスクラスの実装
  - 定義済みのカスタムクエリメソッドを呼び出し、学習日一覧を取得
  - 取得結果が空リストの場合は0を返す
  - リストの先頭から連続する日付をカウントするロジックを実装(途切れた時点でカウントした値を返す)
- 取得した連続投稿日数をビュー上に表示

---
### 動作確認内容

- 手動テスト実施  
  - サイドバーに設定したリンクに正しく遷移することを確認済み  
  - ログイン時に(/dashboard)にリダイレクトされることを確認済み  
- 累計学習時間/累計日報投稿数/連続投稿日数が正しく表示されることを確認
- 日報投稿が0件の場合も正しく表示されることを確認


### 今後の対応（残タスク）

- テストコードの実装  
- JUnitを用いた単体テスト実施
