### PR TITLE
タグ登録機能の実装

### DIFF
--- a/src/main/java/com/example/study/controller/report/ReportController.java
+++ b/src/main/java/com/example/study/controller/report/ReportController.java
@@ -1,5 +1,7 @@
 package com.example.study.controller.report;
 
+import java.util.List;
+
 import jakarta.validation.Valid;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -34,11 +36,12 @@ public class ReportController {
 
 	@GetMapping("/reports")
 	public String getReports(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
-
-		/*テスト用にuserId = 1を決め打ちで入れている*/
 		User user = loginUserProvider.getLoginUser(userDetails);
-
-		model.addAttribute("reports", reportService.getReportsByUserId(user.getId()));
+		List<ReportRequestDto> reports = reportService.getReportsByUserId(user.getId())
+				.stream()
+				.map(reportService::toReportRequestDto)
+				.toList();
+		model.addAttribute("reportRequestDto", reports);
 
 		return "reports";
 	}
@@ -47,7 +50,8 @@ public class ReportController {
 	@GetMapping("/reports/{id}")
 	public String getReport(@PathVariable int id, @AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
 		User user = loginUserProvider.getLoginUser(userDetails);
-		model.addAttribute("report", reportService.getUserOwnedReport(id, user.getId()));
+		Report report = reportService.getUserOwnedReport(id, user.getId());
+		model.addAttribute("reportRequestDto", reportService.toReportRequestDto(report));
 		return "report-detail";
 	}
 

--- a/src/main/java/com/example/study/controller/report/ReportController.java
+++ b/src/main/java/com/example/study/controller/report/ReportController.java
@@ -89,7 +89,7 @@ public class ReportController {
 
 	@PutMapping("/reports")
 	public String editReport(@ModelAttribute @Valid ReportRequestDto dto,
-			@AuthenticationPrincipal CustomUserDetails userDetails, BindingResult result,
+			BindingResult result, @AuthenticationPrincipal CustomUserDetails userDetails,
 			RedirectAttributes redirectAttributes) {
 		if (result.hasErrors()) {
 			return "report-form";
@@ -106,12 +106,12 @@ public class ReportController {
 	public String deleteReport(@PathVariable int id, Model model, RedirectAttributes redirectAttributes,
 			@AuthenticationPrincipal CustomUserDetails userDetails) {
 		User user = loginUserProvider.getLoginUser(userDetails);
-		
+
 		if (!reportService.existById(id)) {
 			redirectAttributes.addFlashAttribute("errorMessage", "指定された日報が見つかりませんでした。");
 			return "redirect:/reports";
 		}
-		
+
 		reportService.deleteReport(id, user.getId());
 		redirectAttributes.addFlashAttribute("successMessage", "日報を削除しました。");
 		return "redirect:/reports";

--- a/src/main/java/com/example/study/controller/tag/TagController.java
+++ b/src/main/java/com/example/study/controller/tag/TagController.java
@@ -1,0 +1,30 @@
+package com.example.study.controller.tag;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.example.study.dto.TagDto;
+import com.example.study.service.TagService;
+
+@Controller
+public class TagController {
+	
+	private final TagService tagService;
+	
+	public TagController(TagService tagService) {
+		this.tagService = tagService;
+	}
+	
+	@GetMapping("/tags/search")
+	public ResponseEntity<List<TagDto>> searchTags(@RequestParam String keyword){
+		//ブラウザ上で「/tags/search?keyword=」のようにアクセスされたときの回避ロジック
+		if(keyword == null || keyword.trim().isEmpty()) {
+			return ResponseEntity.badRequest().build();
+		}
+		return ResponseEntity.ok(tagService.searchTags(keyword));
+	}
+}

--- a/src/main/java/com/example/study/dto/ReportRequestDto.java
+++ b/src/main/java/com/example/study/dto/ReportRequestDto.java
@@ -6,40 +6,47 @@ import java.util.List;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
 public class ReportRequestDto {
 
 	private int id;
-	
+
 	private int userId;
-	
+
 	private String title;
 
 	private String content;
-	
 
 	@DateTimeFormat(pattern = "yyyy-MM-dd")
 
 	private LocalDate learningDate;
-	
+
 	@Min(0)
 	@Max(23)
 	private int learningHours;
-	
+
 	private int learningMinutes;
-	
+
+	private int tagId;
+
+	@NotEmpty(message = "タグ名を入力して下さい")
+	@Size(max = 20, message = "タグ名は{max}文字以内で入力してください")
+	private String tagName;
+
 	public ReportRequestDto() {
-		
+
 	}
-	
+
 	/*カスタムバリデーション*/
 	@AssertTrue(message = "分は0,15,30,45のいずれかを選択してください。")
 	public boolean isValidMinutes() {
-		return List.of(0,15,30,45).contains(learningMinutes);
+		return List.of(0, 15, 30, 45).contains(learningMinutes);
 	}
-	
+
 	public int getId() {
 		return id;
 	}
@@ -47,7 +54,7 @@ public class ReportRequestDto {
 	public void setId(int id) {
 		this.id = id;
 	}
-	
+
 	public int getUserId() {
 		return userId;
 	}
@@ -96,5 +103,20 @@ public class ReportRequestDto {
 		this.learningMinutes = learningMinutes;
 	}
 
+	public int getTagId() {
+		return tagId;
+	}
+
+	public void setTagId(int tagId) {
+		this.tagId = tagId;
+	}
+
+	public String getTagName() {
+		return tagName;
+	}
+
+	public void setTagName(String tagName) {
+		this.tagName = tagName;
+	}
 
 }

--- a/src/main/java/com/example/study/dto/ReportRequestDto.java
+++ b/src/main/java/com/example/study/dto/ReportRequestDto.java
@@ -31,6 +31,8 @@ public class ReportRequestDto {
 
 	private int learningMinutes;
 
+	private double displayLearningTimes;
+
 	private int tagId;
 
 	@NotEmpty(message = "タグ名を入力して下さい")
@@ -45,6 +47,14 @@ public class ReportRequestDto {
 	@AssertTrue(message = "分は0,15,30,45のいずれかを選択してください。")
 	public boolean isValidMinutes() {
 		return List.of(0, 15, 30, 45).contains(learningMinutes);
+	}
+
+	public String capitalizeDisplayTagName() {
+		if (this.tagName == null || this.tagName.isEmpty()) {
+			return "";
+		}
+
+		return this.tagName.substring(0, 1).toUpperCase() + this.tagName.substring(1);
 	}
 
 	public int getId() {
@@ -101,6 +111,14 @@ public class ReportRequestDto {
 
 	public void setLearningMinutes(int learningMinutes) {
 		this.learningMinutes = learningMinutes;
+	}
+
+	public double getDisplayLearningTimes() {
+		return displayLearningTimes;
+	}
+
+	public void setDisplayLearningTimes(double displayLearningTimes) {
+		this.displayLearningTimes = displayLearningTimes;
 	}
 
 	public int getTagId() {

--- a/src/main/java/com/example/study/dto/TagDto.java
+++ b/src/main/java/com/example/study/dto/TagDto.java
@@ -1,0 +1,29 @@
+package com.example.study.dto;
+
+public class TagDto {
+
+	private int tagId;
+	private String tagName;
+
+	public TagDto(int tagId, String tagName) {
+		this.tagId = tagId;
+		this.tagName = tagName;
+	}
+
+	public int getTagId() {
+		return tagId;
+	}
+
+	public void setTagId(int tagId) {
+		this.tagId = tagId;
+	}
+
+	public String getTagName() {
+		return tagName;
+	}
+
+	public void setTagName(String tagName) {
+		this.tagName = tagName;
+	}
+
+}

--- a/src/main/java/com/example/study/entity/Report.java
+++ b/src/main/java/com/example/study/entity/Report.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 @Entity
@@ -31,8 +33,9 @@ public class Report {
 	@Column(name = "learning_hours", nullable = false)
 	private double learningHours;
 
-	@Column(name = "tag_id")
-	private int tagId;
+	@ManyToOne
+	@JoinColumn(name = "tag_id")
+	private Tag tag;
 
 	@Column(name = "created_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
 	private LocalDateTime createdAt;
@@ -92,12 +95,12 @@ public class Report {
 		this.learningHours = learningHours;
 	}
 
-	public int getTagId() {
-		return tagId;
+	public Tag getTag() {
+		return tag;
 	}
 
-	public void setTagId(int tagId) {
-		this.tagId = tagId;
+	public void setTag(Tag tag) {
+		this.tag = tag;
 	}
 
 	public LocalDateTime getCreatedAt() {

--- a/src/main/java/com/example/study/entity/Tag.java
+++ b/src/main/java/com/example/study/entity/Tag.java
@@ -1,0 +1,80 @@
+package com.example.study.entity;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "tags")
+public class Tag {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "tag_id", nullable = false)
+	private int tagId;
+
+	@Column(name = "tag_name", length = 20, unique = true)
+	private String tagName;
+
+	@Column(name = "created_at")
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@PrePersist
+	public void prePersist() {
+		if (Objects.isNull(this.createdAt)) {
+			this.createdAt = LocalDateTime.now();
+		}
+
+		if (Objects.isNull(this.updatedAt)) {
+			this.updatedAt = LocalDateTime.now();
+		}
+	}
+
+	@PreUpdate
+	public void preUpdate() {
+		this.updatedAt = LocalDateTime.now();
+	}
+
+	public int getTagId() {
+		return tagId;
+	}
+
+	public void setTagId(int tagId) {
+		this.tagId = tagId;
+	}
+
+	public String getTagName() {
+		return tagName;
+	}
+
+	public void setTagName(String tagName) {
+		this.tagName = tagName;
+	}
+
+	public LocalDateTime getCreatedAt() {
+		return createdAt;
+	}
+
+	public void setCreatedAt(LocalDateTime createdAt) {
+		this.createdAt = createdAt;
+	}
+
+	public LocalDateTime getUpdatedAt() {
+		return updatedAt;
+	}
+
+	public void setUpdatedAt(LocalDateTime updatedAt) {
+		this.updatedAt = updatedAt;
+	}
+}

--- a/src/main/java/com/example/study/repository/TagRepository.java
+++ b/src/main/java/com/example/study/repository/TagRepository.java
@@ -1,0 +1,10 @@
+package com.example.study.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.study.entity.Tag;
+
+public interface TagRepository extends JpaRepository<Tag, Integer> {
+
+	Tag findByTagName(String lowerCase);
+}

--- a/src/main/java/com/example/study/repository/TagRepository.java
+++ b/src/main/java/com/example/study/repository/TagRepository.java
@@ -1,10 +1,16 @@
 package com.example.study.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import com.example.study.entity.Tag;
 
+@Repository
 public interface TagRepository extends JpaRepository<Tag, Integer> {
 
 	Tag findByTagName(String lowerCase);
+
+	List<Tag> findTop10ByTagNameStartingWithIgnoreCaseOrderByTagName(String tagName);
 }

--- a/src/main/java/com/example/study/service/ReportServiceImpl.java
+++ b/src/main/java/com/example/study/service/ReportServiceImpl.java
@@ -121,6 +121,7 @@ public class ReportServiceImpl implements ReportService {
 		reportRequestDto.setLearningDate(report.getLearningDate());
 		reportRequestDto.setLearningHours(TimeConverter.getHour(report.getLearningHours()));
 		reportRequestDto.setLearningMinutes(TimeConverter.getMinute(report.getLearningHours()));
+		reportRequestDto.setDisplayLearningTimes(report.getLearningHours());
 		reportRequestDto.setTagId(report.getTag().getTagId());
 		reportRequestDto.setTagName(report.getTag().getTagName());
 		

--- a/src/main/java/com/example/study/service/ReportServiceImpl.java
+++ b/src/main/java/com/example/study/service/ReportServiceImpl.java
@@ -3,16 +3,21 @@ package com.example.study.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.study.dto.ReportRequestDto;
 import com.example.study.entity.Report;
+import com.example.study.entity.Tag;
 import com.example.study.exception.ReportNotFoundException;
 import com.example.study.repository.ReportRepository;
+import com.example.study.repository.TagRepository;
 import com.example.study.util.TimeConverter;
+import com.example.study.validation.ReportTagValidator;
 
 @Service
 public class ReportServiceImpl implements ReportService {
@@ -25,9 +30,11 @@ public class ReportServiceImpl implements ReportService {
 	②依存関係が明確でコードが読みやすくなる
 	③テスト時にモック注入がしやすい*/
 	private final ReportRepository reportRepository;
+	private final TagRepository tagRepository;
 
-	public ReportServiceImpl(ReportRepository reportRepository) {
+	public ReportServiceImpl(ReportRepository reportRepository, TagRepository tagRepository) {
 		this.reportRepository = reportRepository;
+		this.tagRepository = tagRepository;
 	}
 
 	@Override
@@ -59,6 +66,14 @@ public class ReportServiceImpl implements ReportService {
 
 	@Transactional
 	public void createReport(ReportRequestDto dto) {
+		//タグ名を小文字に変換して検索を実施(Java,javaが区別されないようDB登録時にすべて小文字変換して登録しているため)
+		String cleanedTagName = normalizeTagName(dto.getTagName());
+
+		/* Controllerでのバリデーションが適用されないケースに備えた再チェック
+		   例)他のServiceクラスから直接呼び出された場合*/
+		ReportTagValidator.validateTagName(cleanedTagName);
+		Tag tag = getTagForReport(tagRepository.findByTagName(cleanedTagName), cleanedTagName);
+
 		Report report = new Report();
 		report.setUserId(dto.getUserId());
 		report.setTitle(dto.getTitle());
@@ -71,10 +86,29 @@ public class ReportServiceImpl implements ReportService {
 		report.setUpdatedAt(LocalDateTime.now());
 		report.setCreatedAt(LocalDateTime.now());
 
-		//タグ自動登録機能を実装するまではtagId=1で固定
-		report.setTagId(1);
+		//既存のタグ名が見つかれば取得した値をReportクラスにセットし登録
+		report.setTag(tag);
 
 		reportRepository.save(report);
+	}
+
+	private Tag getTagForReport(Tag tag, String cleanedTagName) {
+
+		//タグ名が見つからなければタグ登録を実施&新規登録したレコード情報を再取得
+		if (Objects.isNull(tag)) {
+			Tag newTag = new Tag();
+			newTag.setTagName(cleanedTagName);
+			try {
+				tag = tagRepository.save(newTag);
+			} catch (DataIntegrityViolationException e) {
+				tag = tagRepository.findByTagName(cleanedTagName);
+			}
+		}
+		return tag;
+	}
+
+	private String normalizeTagName(String tagName) {
+		return tagName.trim().toLowerCase();
 	}
 
 	@Override
@@ -87,21 +121,27 @@ public class ReportServiceImpl implements ReportService {
 		reportRequestDto.setLearningDate(report.getLearningDate());
 		reportRequestDto.setLearningHours(TimeConverter.getHour(report.getLearningHours()));
 		reportRequestDto.setLearningMinutes(TimeConverter.getMinute(report.getLearningHours()));
-
+		reportRequestDto.setTagId(report.getTag().getTagId());
+		reportRequestDto.setTagName(report.getTag().getTagName());
+		
 		return reportRequestDto;
 	}
 
 	@Override
 	@Transactional
 	public void updateReport(ReportRequestDto dto, int userId) {
+		String cleanedTagName = normalizeTagName(dto.getTagName());
+		ReportTagValidator.validateTagName(cleanedTagName);
 		// dtoについてはControllerクラスにてバリデーションチェック済み
 		Report report = getReportById(dto.getId());
-
 		validateOwnership(report, userId);
+
+		Tag tag = getTagForReport(tagRepository.findByTagName(cleanedTagName), cleanedTagName);
 
 		report.setTitle(dto.getTitle());
 		report.setContent(dto.getContent());
 		report.setLearningDate(dto.getLearningDate());
+		report.setTag(tag);
 
 		//〇時間〇分→〇.〇hに変換して設定(DB定義に合わせるため)
 		report.setLearningHours(dto.getLearningHours() + (dto.getLearningMinutes() / MINUTES_PER_HOUR));
@@ -159,7 +199,7 @@ public class ReportServiceImpl implements ReportService {
 			if (learningDays.get(i).equals(prevDate.minusDays(1))) {
 				consecutiveCount++;
 				prevDate = learningDays.get(i);
-				
+
 			} else {
 				return consecutiveCount;
 			}

--- a/src/main/java/com/example/study/service/TagService.java
+++ b/src/main/java/com/example/study/service/TagService.java
@@ -1,0 +1,9 @@
+package com.example.study.service;
+
+import java.util.List;
+
+import com.example.study.dto.TagDto;
+
+public interface TagService {
+	List<TagDto> searchTags(String keyword);
+}

--- a/src/main/java/com/example/study/service/TagServiceImpl.java
+++ b/src/main/java/com/example/study/service/TagServiceImpl.java
@@ -1,0 +1,28 @@
+package com.example.study.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.example.study.dto.TagDto;
+import com.example.study.repository.TagRepository;
+
+@Service
+public class TagServiceImpl implements TagService {
+
+	private final TagRepository tagRepository;
+	
+	public TagServiceImpl(TagRepository tagRepository) {
+		this.tagRepository = tagRepository;
+	}
+	
+	@Override
+	public List<TagDto> searchTags(String tagName) {
+		return tagRepository
+				.findTop10ByTagNameStartingWithIgnoreCaseOrderByTagName(tagName)
+				.stream()
+				.map(tag -> new TagDto(tag.getTagId(),tag.getTagName()))
+				.toList();
+	}
+
+}

--- a/src/main/java/com/example/study/validation/ReportTagValidator.java
+++ b/src/main/java/com/example/study/validation/ReportTagValidator.java
@@ -1,0 +1,16 @@
+package com.example.study.validation;
+
+public class ReportTagValidator{
+	public static void validateTagName(String tagName) {
+		
+		//null or 空白だけの文字列は禁止
+		if (tagName == null || tagName.trim().isEmpty()) {
+			throw new  IllegalArgumentException("タグ名を入力してください。"); 
+		}
+		
+		if(tagName.length()> 20) {
+			throw new  IllegalArgumentException("タグ名は20文字以内で入力してください。");
+		}
+	}
+	
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -95,3 +95,44 @@ table {
 .summary-value {
     font-size: 1.2em;
 }
+
+.suggest-container {
+  position: relative;
+  width: 300px; /* 適宜調整 */
+}
+
+#suggestionList {
+  position: absolute;
+  top: 100%; /* 入力欄のすぐ下に配置 */
+  left: 0;
+  width: 100%;
+  max-height: 200px;
+  overflow-y: auto;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  background-color: white;
+  border: none;
+  z-index: 1000;
+  box-shadow: 0px 2px 6px rgba(0,0,0,0.1);
+}
+
+#suggestionList li {
+  padding: 8px;
+  cursor: pointer;
+}
+
+#suggestionList li:hover {
+  background-color: #f0f0f0;
+}
+
+.form-row {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1em;
+}
+
+.form-row label {
+  margin-right: 8px;
+  min-width: 60px;
+}

--- a/src/main/resources/static/js/suggest.js
+++ b/src/main/resources/static/js/suggest.js
@@ -1,0 +1,47 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const input = document.getElementById('tagInput');
+    const suggestionList = document.getElementById('suggestionList');
+
+    input.addEventListener('keyup', async function() {
+		console.log('入力検知:', input.value);
+        const keyword = input.value.trim();
+        
+        // 入力が空ならサジェストをクリア
+        if (keyword === '') {
+            suggestionList.innerHTML = '';
+            return;
+        }
+
+        try {
+            // fetchでAjaxリクエスト
+            const response = await fetch(`/tags/search?keyword=${encodeURIComponent(keyword)}`);
+			console.log('fetch完了：', response);
+            if (!response.ok) {
+                console.error('通信エラー:', response.status);
+                return;
+            }
+
+            const tags = await response.json();
+
+            // サジェストリストを更新
+            suggestionList.innerHTML = '';
+            tags.forEach(tag => {
+                const li = document.createElement('li');
+                li.textContent = capitalizeFirstLetter(tag.tagName);
+                li.addEventListener('click', function() {
+                    input.value = li.textContent;  // クリックしたタグを入力欄にセット
+                    suggestionList.innerHTML = ''; // サジェストをクリア
+                });
+                suggestionList.appendChild(li);
+            });
+        } catch (error) {
+            console.error('エラー発生:', error);
+        }
+    });
+
+    // 先頭文字だけ大文字にするヘルパー関数
+    function capitalizeFirstLetter(str) {
+        if (!str) return '';
+        return str.charAt(0).toUpperCase() + str.slice(1);
+    }
+});

--- a/src/main/resources/templates/report-detail.html
+++ b/src/main/resources/templates/report-detail.html
@@ -12,26 +12,30 @@
     <table border="1" cellpadding="8">
         <tr>
             <th>日付</th>
-            <td th:text="${report.learningDate}">2025-04-01</td>
+            <td th:text="${reportRequestDto.learningDate}">2025-04-01</td>
         </tr>
         <tr>
             <th>学習概要</th>
-            <td th:text="${report.title}">Java</td>
+            <td th:text="${reportRequestDto.title}">Java</td>
         </tr>
 		<tr>
             <th>学習内容</th>
-            <td th:text="${report.content}">Spring BootのREST APIを学習</td>
+            <td th:text="${reportRequestDto.content}">Spring BootのREST APIを学習</td>
         </tr>
+		<tr>
+			<th>タグ名</th>
+			<td th:text="${reportRequestDto.capitalizeDisplayTagName()}">Java</td>
+		</tr>
         <tr>
             <th>学習時間</th>
-            <td th:text="${report.learningHours}">0h</td>
+            <td th:text="${reportRequestDto.displayLearningTimes}">0h</td>
         </tr>
     </table>
 
     <br />
 
     <div>
-		<form th:action="@{/reports/edit/{id}(id=${report.id})}" method="get" style="display: inline;">
+		<form th:action="@{/reports/edit/{id}(id=${reportRequestDto.id})}" method="get" style="display: inline;">
 	        <button type="submit">編集</button>
 	    </form>
 
@@ -41,7 +45,7 @@
     </div>
 
     <!-- 削除ボタン -->
-    <form th:action="@{/reports/{id}(id=${report.id})}" method="post" style="margin-top: 10px;">
+    <form th:action="@{/reports/{id}(id=${reportRequestDto.id})}" method="post" style="margin-top: 10px;">
         <input type="hidden" name="_method" value="delete" />
         <button type="submit" onclick="return confirm('本当に削除しますか？')">削除</button>
     </form>

--- a/src/main/resources/templates/report-form.html
+++ b/src/main/resources/templates/report-form.html
@@ -3,6 +3,8 @@
 <head>
     <title>日報フォーム</title>
     <meta charset="UTF-8" />
+	<link rel="stylesheet" th:href="@{/css/style.css}">
+	<script src="/js/suggest.js"></script>
 </head>
 <body>
 	<header th:replace="~{header::headerArea}"></header>
@@ -23,10 +25,13 @@
             <input type="date" th:field="*{learningDate}" required />
         </div>
 
-        <div>
-			<div th:if="${#fields.hasErrors('tagName')}" th:errors="*{tagName}" style="color:red"></div>
-            <label>タグ名:</label>
-			<input type="text" th:field="*{tagName}" required />
+		<div th:if="${#fields.hasErrors('tagName')}" th:errors="*{tagName}" style="color:red"></div>
+        <div class="form-row">
+            <label for="tagInput">タグ名:</label>
+			<div class="suggest-container">
+				<input type="text" id="tagInput" placeholder="タグを入力" th:field="*{tagName}" required />
+				<ul id="suggestionList"></ul>
+			</div>
         </div>
 		<div>
 			<div th:if="${#fields.hasErrors('title')}" th:errors="*{title}" style="color:red"></div>
@@ -38,7 +43,6 @@
 			<div th:if="${#fields.hasErrors('content')}" th:errors="*{content}" style="color:red"></div>
             <label>学習内容:</label><br>
             <textarea th:field="*{content}" rows="5" cols="50" required></textarea><br>
-<!--            <span th:text="'文字数: ' + ${#strings.length(reportForm.content)} + '文字'"></span>-->
         </div>
 
         <div>
@@ -49,10 +53,6 @@
 			    <option th:value="${i}" th:text="${i}">0</option>
 			  </th:block>
 			</select>
-<!--            <select th:field="*{learningHours}">-->
-<!--                <option th:each="i : ${#numbers.sequence(1, 12)}"-->
-<!--                        th:value="${i}" th:text="${i + ' 時間'}"></option>-->
-<!--            </select>-->
 			<label>学習時間(分)</label>
 			<select id="learningMinutes" name="learningMinutes" th:field="*{learningMinutes}">
 			  <option value="0">0</option>

--- a/src/main/resources/templates/report-form.html
+++ b/src/main/resources/templates/report-form.html
@@ -29,7 +29,8 @@
         <div class="form-row">
             <label for="tagInput">タグ名:</label>
 			<div class="suggest-container">
-				<input type="text" id="tagInput" placeholder="タグを入力" th:field="*{tagName}" required />
+				<input type="text" id="tagInput" placeholder="タグを入力" th:field="*{tagName}" 
+				 th:value="${reportRequestDto.capitalizeDisplayTagName()}" required />
 				<ul id="suggestionList"></ul>
 			</div>
         </div>

--- a/src/main/resources/templates/report-form.html
+++ b/src/main/resources/templates/report-form.html
@@ -23,14 +23,11 @@
             <input type="date" th:field="*{learningDate}" required />
         </div>
 
-<!--        <div>-->
-<!--            <label>技術カテゴリー:</label>-->
-<!--            <select th:field="*{tech}">-->
-<!--                <option value="">-- 選択してください --</option>-->
-<!--                <option th:each="t : ${techList}"-->
-<!--                        th:value="${t}" th:text="${t}"></option>-->
-<!--            </select>-->
-<!--        </div>-->
+        <div>
+			<div th:if="${#fields.hasErrors('tagName')}" th:errors="*{tagName}" style="color:red"></div>
+            <label>タグ名:</label>
+			<input type="text" th:field="*{tagName}" required />
+        </div>
 		<div>
 			<div th:if="${#fields.hasErrors('title')}" th:errors="*{title}" style="color:red"></div>
             <label>学習概要:</label>

--- a/src/main/resources/templates/reports.html
+++ b/src/main/resources/templates/reports.html
@@ -31,11 +31,11 @@
 					</tr>
 				</thead>
 				<tbody>
-					<tr th:each="report : ${reports}">
+					<tr th:each="report : ${reportRequestDto}">
 						<td th:text="${report.learningDate}"></td>
 						<td th:text="${report.title}"></td>
 						<td th:text="${report.content}"></td>
-						<td th:text="${report.learningHours}"></td>
+						<td th:text="${report.displayLearningTimes}"></td>
 						<td>
 							<!-- 詳細ボタン -->
 							<form th:action="@{'/reports/' + ${report.id}}" method="get" style="display:inline;">


### PR DESCRIPTION
タグ登録機能の実装が完了しました。

[タグ登録機能の実装 #18](https://github.com/kirias1996/studyLog/issues/18)の内容に基づいて実装しました。

### 実装概要

- タグ項目のバリデーションチェック実装
- ユーザ入力タグを小文字化してDB登録
- 既存タグがあればタグIDを取得して登録、なければ新規タグを登録し、タグIDを取得し,reportsテーブルに登録/更新
- tag検索用エンドポイント(GET:/tags/search?keyword=XXX)を実装()
- JavaScriptを用いたサジェスト機能の実装(表示候補は最大10件)
- 日報詳細/日報フォーム画面で先頭を大文字化して表示する処理を実装