### PR TITLE
画像表示/アップロード処理をCloudinaryサービスへ移行

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'com.cloudinary:cloudinary-http44:1.37.0'
 	implementation 'org.postgresql:postgresql:42.6.0'
 	implementation 'io.github.cdimascio:java-dotenv:5.2.1'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/study/config/CloudinaryConfig.java
+++ b/src/main/java/com/example/study/config/CloudinaryConfig.java
@@ -1,0 +1,20 @@
+package com.example.study.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.cloudinary.Cloudinary;
+
+@Configuration
+public class CloudinaryConfig {
+	
+	@Value("${cloudinary.url}")
+	private String baseImageUrl;
+
+    @Bean
+    Cloudinary cloudinary() {
+		return new Cloudinary(baseImageUrl);
+	}
+
+}

--- a/src/main/java/com/example/study/dto/UserProfileDto.java
+++ b/src/main/java/com/example/study/dto/UserProfileDto.java
@@ -21,6 +21,8 @@ public class UserProfileDto {
 	
 	private MultipartFile iconImage;
 	
+	private String iconPublicId;
+	
 	private boolean defaultIcon;
 	
 	public UserProfileDto() {
@@ -64,6 +66,14 @@ public class UserProfileDto {
 
 	public void setIconImage(MultipartFile iconImage) {
 		this.iconImage = iconImage;
+	}
+
+	public String getIconPublicId() {
+		return iconPublicId;
+	}
+
+	public void setIconPublicId(String iconPublicId) {
+		this.iconPublicId = iconPublicId;
 	}
 
 	public boolean isDefaultIcon() {

--- a/src/main/java/com/example/study/entity/User.java
+++ b/src/main/java/com/example/study/entity/User.java
@@ -39,6 +39,10 @@ public class User {
 	@Size(max = 255)
 	@Column(name = "icon_url")
 	private String iconUrl;
+	
+	@Size(max = 255)
+	@Column(name = "icon_public_id")
+	private String iconPublicId;
 
 	@Column(name = "created_at", insertable = true, updatable = false)
 	private LocalDateTime createdAt;
@@ -104,6 +108,14 @@ public class User {
 
 	public void setIconUrl(String iconUrl) {
 		this.iconUrl = iconUrl;
+	}
+
+	public String getIconPublicId() {
+		return iconPublicId;
+	}
+
+	public void setIconPublicId(String iconPublicId) {
+		this.iconPublicId = iconPublicId;
 	}
 
 	public LocalDateTime getCreatedAt() {

--- a/src/main/java/com/example/study/service/ImageService.java
+++ b/src/main/java/com/example/study/service/ImageService.java
@@ -1,0 +1,14 @@
+package com.example.study.service;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageService {
+
+	Map<String, Object> upload(MultipartFile file, Map<String, Object> param) throws IOException;
+
+	void deleteFile(String publicId);
+
+}

--- a/src/main/java/com/example/study/util/CloudinaryParamsHelper.java
+++ b/src/main/java/com/example/study/util/CloudinaryParamsHelper.java
@@ -1,0 +1,20 @@
+package com.example.study.util;
+
+import java.util.Map;
+
+import com.cloudinary.utils.ObjectUtils;
+
+public class CloudinaryParamsHelper {
+	
+	private CloudinaryParamsHelper() {
+		
+	}
+
+	public static Map<String, Object> defaultParams(String publicId) {
+		return ObjectUtils.asMap(
+				"public_id", publicId,
+				"overwrite", true
+				);
+	}
+
+}

--- a/src/main/java/com/example/study/util/InputValidator.java
+++ b/src/main/java/com/example/study/util/InputValidator.java
@@ -1,0 +1,33 @@
+package com.example.study.util;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public class InputValidator {
+
+	private InputValidator() {
+
+	}
+
+	public static boolean isNotBlank(String str) {
+		return str != null && !str.isBlank();
+	}
+
+	public static boolean isBlank(String str) {
+		return str == null || str.isBlank();
+	}
+
+	/*
+	 * 空文字のみtrue(" "や"\n"を含むとfalse)
+	 * */
+	public static boolean isEmptyOnly(String str) {
+		return str != null && str.isEmpty();
+	}
+
+	public static boolean isNotEmpty(MultipartFile file) {
+		return file != null && !file.isEmpty();
+	}
+
+	public static boolean isEmpty(MultipartFile file) {
+		return file == null || file.isEmpty();
+	}
+}

--- a/src/main/java/com/example/study/validation/UserProfileValidator.java
+++ b/src/main/java/com/example/study/validation/UserProfileValidator.java
@@ -35,8 +35,8 @@ public class UserProfileValidator implements Validator {
 
 	private void validateFileExtension(MultipartFile file, Errors errors) {
 		/*(?i)で大文字/小文字を区別しない正規表現マッチングを適用*/
-		if (file.getOriginalFilename() != null || !file.isEmpty()
-				|| !file.getOriginalFilename().matches("(?i)^.+\\.(png|jpg|jpeg)$")) {
+		if (file.getOriginalFilename() != null && !file.isEmpty()
+				&& !file.getOriginalFilename().matches("(?i)^.+\\.(png|jpg|jpeg)$")) {
 			errors.rejectValue("iconImage", "file.invalid", "対応していないファイル形式です。PNGまたはJPG形式の画像を指定してください。");
 		}
 	}

--- a/src/main/resources/templates/userProfile/userProfileEdit.html
+++ b/src/main/resources/templates/userProfile/userProfileEdit.html
@@ -61,7 +61,7 @@
 			</div>
 
 		</div>
-
+		<input type="hidden" name="iconPublicId" th:value="*{iconPublicId}" />
 		<br>
 
 		<!-- 送信ボタン -->

--- a/src/main/resources/templates/userProfile/userProfileView.html
+++ b/src/main/resources/templates/userProfile/userProfileView.html
@@ -19,6 +19,7 @@
 		        <!-- プロフィール画像 -->
 		        <img th:src="@{${userProfile.iconUrl}}" alt="プロフィール画像" width="150" height="150">
 		    </div>
+			<input type="hidden" name="iconPublicId" th:value="${userProfile.iconPublicId}" />
 		
 		    <div>
 		        <p><strong>ユーザ名：</strong> <span th:text="${userProfile.userName}">ユーザ名</span></p>


### PR DESCRIPTION
## 概要
[画像表示/アップロード処理をCloudinaryサービスへの差し替え対応 #30 ](https://github.com/kirias1996/studyLog/issues/30#issue-3076662455) をもとに実装しました。
Cloudinaryとの連携機能を追加し、ユーザプロフィール画像のアップロード・表示・削除処理を実装しました。

---

## ✅ 対応内容

### ◾ Cloudinary画像アップロード処理（#1）
- 一意な `public_id`（`user_{id}_{UUID}`）を生成
- Cloudinaryに `public_id` を指定して画像アップロード
- `secure_url` / `public_id` を取得し、エンティティにセット
- hiddenで渡された旧 `public_id` と異なる場合、旧画像をCloudinaryから削除
- DB保存失敗時は、新しい `public_id` によるCloudinary画像も削除

### ◾ Cloudinary画像表示処理（#2）
- Cloudinaryの `secure_url` を `iconUrl` としてビューに連携し表示

---

## 🧪 動作確認（#3）

- [x] ユーザ新規作成時にデフォルトアイコンが表示されることを確認
- [x] プロフィール画像を変更した際、旧画像が削除され新しい画像が表示されることを確認
- [x] `.txt` や 2MB超過ファイルをアップロードするとバリデーションエラーが返ることを確認
- [x] プロフィール画像変更操作をキャンセルしても画像がnullにならないことを確認

---

## ⏱️ 工数目安（合計4.5時間）

| 作業項目                     | 工数        |
|------------------------------|-------------|
| Cloudinaryアップロード処理    | 2.0時間（想定1.5h + バッファ0.5h） |
| Cloudinary画像表示処理        | 0.5時間     |
| 動作確認                     | 1.0時間     |
| 想定外対応バッファ             | 1.0時間     |

---