### PR TITLE
Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Build and Deploy with Java 21
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Grant permission to Gradle
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build -x test -x check
+

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ out/
 # application.properties / application.yml �̂����A�����Ƃɐ؂�ւ���ݒ�͕K�v�ɉ����ď��O
 src/main/resources/application-dev.properties
 src/main/resources/application-local.properties
-src/main/resources/application-prod.properties
 *.launch
 
 # アプリケーション

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+cloudinary.cloud.name=${CLOUDINARY_CLOUD_NAME}
+cloudinary.api.key=${CLOUDINARY_API_KEY}
+cloudinary.api.secret=${CLOUDINARY_API_SECRET}
+cloudinary.url=${CLOUDINARY_URL}

--- a/src/main/resources/application-sample.properties
+++ b/src/main/resources/application-sample.properties
@@ -1,3 +1,7 @@
 spring.datasource.url=jdbc:postgresql://<DB_HOST>:<PORT>/<DB_NAME>
 spring.datasource.username=<DB_USERNAME>
 spring.datasource.password=<DB_PASSWORD>
+cloudinary.cloud.name=<CLOUDINARY_CLOUD_NAME>
+cloudinary.api.key=<CLOUDINARY_API_KEY>
+cloudinary.api.secret=<CLOUDINARY_API_SECRET>
+cloudinary.url=<CLOUDINARY_URL>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.application.name=StudyLog
 spring.datasource.driver-class-name=org.postgresql.Driver
+spring.sql.init.mode=never
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.profiles.active=${HOST}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,62 @@
+
+
+CREATE TABLE IF NOT EXISTS public.auth
+(
+    id SERIAL NOT NULL,
+    email character varying(255) COLLATE pg_catalog."default" NOT NULL,
+    password_hash character varying(255) COLLATE pg_catalog."default" NOT NULL,
+    role character varying(255) COLLATE pg_catalog."default" DEFAULT 'USER'::character varying,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT auth_pkey PRIMARY KEY (id),
+    CONSTRAINT auth_email_key UNIQUE (email)
+);
+
+CREATE TABLE IF NOT EXISTS public.tags
+(
+    tag_id SERIAL NOT NULL,
+    tag_name character varying(20) COLLATE pg_catalog."default" NOT NULL,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT tags_pkey PRIMARY KEY (tag_id),
+    CONSTRAINT tags_tag_name_key UNIQUE (tag_name)
+);
+
+CREATE TABLE IF NOT EXISTS public.users
+(
+    id SERIAL NOT NULL,
+    auth_id integer NOT NULL,
+    user_name character varying(50) COLLATE pg_catalog."default" NOT NULL,
+    profile_text character varying(255) COLLATE pg_catalog."default",
+    icon_url character varying(255) COLLATE pg_catalog."default",
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now(),
+    icon_public_id character varying(255) COLLATE pg_catalog."default",
+    CONSTRAINT users_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_users_auth FOREIGN KEY (auth_id)
+        REFERENCES public.auth (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+);
+
+CREATE TABLE IF NOT EXISTS public.reports
+(
+    id SERIAL NOT NULL,
+    user_id integer NOT NULL,
+    title character varying(255) COLLATE pg_catalog."default" NOT NULL,
+    content character varying(255) COLLATE pg_catalog."default" NOT NULL,
+    learning_date date NOT NULL,
+    learning_hours double precision NOT NULL,
+    tag_id integer,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT reports_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_reports_tag_id FOREIGN KEY (tag_id)
+        REFERENCES public.tags (tag_id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION,
+    CONSTRAINT fk_reports_user_id FOREIGN KEY (user_id)
+        REFERENCES public.users (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE CASCADE
+);


### PR DESCRIPTION
### deploy.ymlの新規作成
- RailwayのデフォルトJava環境が17のため、Java21でビルドする場合はGitHub Actionsによるカスタムビルドが必要となる
- Java21環境でのデプロイ用に `.github/workflows/deploy.yml` を作成し、GitHub Actions によるデプロイを実現

### schema.sqlの作成
- ユニークキーなどの制約をpgAdminで確認・作成し、DDL文を `schema.sql` に保存
- 将来的にFlywayなどマイグレーションツールへ移行しやすくするため、DDLはリポジトリ管理
- アプリケーション起動時には `schema.sql` は実行しない方針
- 初回以降の定義変更はJPAの自動更新機能（ddl-auto=update）で対応

### 本番用/サンプル用 application.properties の更新
- `application-prod.properties` を管理対象に追加し、本番デプロイ時に読み込まれるよう設定
- `application-sample.properties` にCloudinary関連の環境変数項目を追加
- SQL初期化防止のため、`spring.sql.init.mode=never` を明示的に追加

### ファイル一覧
- 追加：`.github/workflows/deploy.yml`
- 追加：`src/main/resources/schema.sql`
- 変更：`application-prod.properties`
- 変更：`application-sample.properties`
- - 変更：`application.properties`


