### PR TITLE
デプロイ用資材更新

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,11 @@
+[phases.setup]
+nixPkgs = ['jdk21']
+
+[phases.build]
+cmds = [
+  "chmod +x ./gradlew",
+  "./gradlew clean bootJar"
+]
+
+[start]
+cmd = "java -jar build/libs/StudyLog-0.0.1-SNAPSHOT.jar --spring.profiles.active=prod"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,6 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.sql.init.mode=never
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.profiles.active=${HOST}
 spring.mvc.hiddenmethod.filter.enabled=true
 app.default-icon-path=/image/default-icon.png
 spring.servlet.multipart.max-file-size=10MB


### PR DESCRIPTION
### application.propertiesの記述修正
- 不要な環境変数を読み込む記述が書かれてしまっていたので削除
- 起動コマンドに引数(--spring.profiles.active=prod)を指定することで対応


### nixpacks.toml
- デプロイ先のホスト環境であるRailwayでJDK21が使えるようファイルを追加