### PR TITLE
デプロイ時のコマンド&生成されるjarファイル名の修正

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,10 @@ plugins {
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
+bootJar {
+    archiveFileName = "StudyLog.jar"
+}
+
 java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(21)

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,11 +1,5 @@
 [phases.setup]
 nixPkgs = ['jdk21']
 
-[phases.build]
-cmds = [
-  "chmod +x ./gradlew",
-  "./gradlew clean bootJar"
-]
-
 [start]
-cmd = "java -jar build/libs/StudyLog-0.0.1-SNAPSHOT.jar --spring.profiles.active=prod"
+cmd = "java -jar build/libs/StudyLog.jar --spring.profiles.active=prod"


### PR DESCRIPTION
### build.gradle
- ビルド時に生成されるJarファイル名を「StudyLog.jar」に修正

### nixpacks.toml
- deploy.ymlに記載済みのビルドコマンドを削除
- 起動するjarファイル名の修正