### PR TITLE
Railwayの変数読み込み処理の修正対応

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,16 +1,5 @@
 [phases.setup]
 nixPkgs = ['jdk21']
 
-[phases.build]
-cmds = [
-  "echo \"DB_URL=$DB_URL\" > .env",
-  "echo \"DB_USERNAME=$DB_USERNAME\" >> .env",
-  "echo \"DB_PASSWORD=$DB_PASSWORD\" >> .env",
-  "echo \"CLOUDINARY_API_KEY=$CLOUDINARY_API_KEY\" >> .env",
-  "echo \"CLOUDINARY_API_SECRET=$CLOUDINARY_API_SECRET\" >> .env",
-  "echo \"CLOUDINARY_CLOUD_NAME=$CLOUDINARY_CLOUD_NAME\" >> .env",
-  "echo \"CLOUDINARY_URL=cloudinary://$CLOUDINARY_API_KEY:$CLOUDINARY_API_SECRET@$CLOUDINARY_CLOUD_NAME\" >> .env"
-]
-
 [start]
 cmd = "bash ./scripts/start.sh"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
-set -eux
+set -eu
+
+echo "[start.sh] 開始: 環境変数を .env に書き出します..."
+echo "DB_URL=${DB_URL}" > .env
+echo "DB_USERNAME=${DB_USERNAME}" >> .env
+echo "DB_PASSWORD=${DB_PASSWORD}" >> .env
+echo "CLOUDINARY_API_KEY=${CLOUDINARY_API_KEY}" >> .env
+echo "CLOUDINARY_API_SECRET=${CLOUDINARY_API_SECRET}" >> .env
+echo "CLOUDINARY_CLOUD_NAME=${CLOUDINARY_CLOUD_NAME}" >> .env
+echo "CLOUDINARY_URL=cloudinary://${CLOUDINARY_API_KEY}:${CLOUDINARY_API_SECRET}@${CLOUDINARY_CLOUD_NAME}" >> .env
 
 echo "[start.sh] 開始：環境変数を読み込みます..."
 source .env
 
-echo "[start.sh] .env を削除します（セキュリティ対策）..."
-rm .env
-
 echo "[start.sh] Spring Boot アプリケーションを起動します..."
 java -jar build/libs/StudyLog.jar --spring.profiles.active=prod
+
+echo "[start.sh] .env を削除します（セキュリティ対策）..."
+rm .env


### PR DESCRIPTION
### 発生した事象
- Railwayのデプロイにて環境変数がうまく読み込まれずアプリケーション起動に失敗していた。

### 原因
- RailwayのVariablesはnixpacks.tomlのstartフェーズでのみ自動注入される仕様
- デプロイ時はbuildフェーズに変数読み込み処理を書いていたため、注入されなかった。


### 対策
- nixpacks.tomlのstartフェーズ(実行するシェルスクリプト)で変数を読み込み、.envファイルに書き込む処理に修正。
- 実行時のオプションからxを削除しログ出力を抑止(DB接続URLなどの機密情報をログ出力してしまう可能性があったため)


### 修正内容
- nixpacks.toml
  - .envファイルに書き込む処理の削除
- scripts/start.sh
  - .実行オプション(x)を削除しログ出力を抑止
  - .envファイルに書き込む処理の作成
  - セキュリティ対策用.envの削除をアプリケーション起動後に移動（source 実行前に削除すると読み込みに失敗するため）