### PR TITLE
ユーザプロフィール編集機能でアイコン画像未選択時にユーザ名&プロフィール文の更新が反映されない不具合の修正対応

### DIFF
--- a/src/main/java/com/example/study/controller/userProfile/UserProfileController.java
+++ b/src/main/java/com/example/study/controller/userProfile/UserProfileController.java
@@ -93,7 +93,7 @@ public class UserProfileController {
 		User user = loginUserProvider.getLoginUser(userDetails);
 		userProfileService.updateUserProfile(user, dto);
 		redirectAttributes.addFlashAttribute("successMessage",
-				messageUtil.getMessage("createUser.success", null, LocaleContextHolder.getLocale()));
+				messageUtil.getMessage("editUserProfile.success", null, LocaleContextHolder.getLocale()));
 
 		return "redirect:/userProfile";
 	}

--- a/src/main/java/com/example/study/util/CloudinaryParamsHelper.java
+++ b/src/main/java/com/example/study/util/CloudinaryParamsHelper.java
@@ -10,10 +10,11 @@ public class CloudinaryParamsHelper {
 		
 	}
 
-	public static Map<String, Object> defaultParams(String publicId) {
+	public static Map<String, Object> defaultParams(String publicId,String uploadFolder) {
 		return ObjectUtils.asMap(
 				"public_id", publicId,
-				"overwrite", true
+				"overwrite", true,
+				"folder",uploadFolder
 				);
 	}
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -5,3 +5,4 @@ cloudinary.cloud.name=${CLOUDINARY_CLOUD_NAME}
 cloudinary.api.key=${CLOUDINARY_API_KEY}
 cloudinary.api.secret=${CLOUDINARY_API_SECRET}
 cloudinary.url=${CLOUDINARY_URL}
+cloudinary.upload.folder=prod_upload_folder

--- a/src/main/resources/templates/userProfile/userProfileEdit.html
+++ b/src/main/resources/templates/userProfile/userProfileEdit.html
@@ -42,13 +42,15 @@
                     <textarea id="profileText" th:field="*{profileText}" rows="5" cols="40"></textarea>
                 </div>
                 <br>
-
                 <div class="profileedit-main-contents">
                     <div th:if="${#fields.hasErrors('iconImage')}" style="color: red;">
                         <ul>
                             <li th:each="err : ${#fields.errors('iconImage')}" th:text="${err}"></li>
                         </ul>
                     </div>
+					<div>
+	                    <img th:src="@{${userProfile.iconUrl}}" alt="プロフィール画像" width="150" height="150">
+	                </div>
                     <label class="main-text" for="iconImage">アイコン画像</label><br>
                     <input type="file" id="iconImage" name="iconImage" />
                 </div>


### PR DESCRIPTION
[ユーザプロフィール編集機能の更新バグについて #47](https://github.com/kirias1996/studyLog/issues/47)について修正を実施いたしました。

### 修正内容
- 編集完了後のメッセージコード誤りを修正
- 画像未選択の時にも既存のアイコン情報を用いて更新処理を行う実装へ修正
- 利用環境ごとにアップロードフォルダを振り分ける修正を実施
    - application-xxx.propertiesに記述したフォルダを読み込む形式を採用