### PR TITLE
日報編集画面でエラーが出た際に登録フォームが表示される不具合改修

### DIFF
--- a/src/main/java/com/example/study/controller/report/ReportController.java
+++ b/src/main/java/com/example/study/controller/report/ReportController.java
@@ -109,8 +109,9 @@ public class ReportController {
 	@PutMapping("/reports")
 	public String editReport(@ModelAttribute("reportRequestDto") @Valid ReportRequestDto dto,
 			BindingResult result, @AuthenticationPrincipal CustomUserDetails userDetails,
-			RedirectAttributes redirectAttributes) {
+			RedirectAttributes redirectAttributes,Model model) {
 		if (result.hasErrors()) {
+			model.addAttribute("isEdit", true);
 			return "report-form";
 		}
 		User user = loginUserProvider.getLoginUser(userDetails);


### PR DESCRIPTION
下記対応を実施いたしました。

日報編集画面においてバリデーションチェック処理等でエラーが発生した際に日報登録画面が表示される不具合を修正しました。

- リクエストスコープに「isEdit:true」を追加
